### PR TITLE
fix(debug): remove pre tag around code blocks

### DIFF
--- a/layouts/debug.html
+++ b/layouts/debug.html
@@ -66,15 +66,13 @@
 <details>
   <!-- prettier-ignore -->
   <summary><code>$ cat <a href='{{ $ghrepo }}/blob/{{ $git_hash }}/flake.lock'>flake.lock</a></code></summary>
-  {{ with os.ReadFile "flake.lock" }}
-    {{ highlight (trim . "\n\r") "json" }}
-  {{ end }}
+  {{ with os.ReadFile "flake.lock" }} {{ highlight (trim . "\n\r") "json" }} {{
+  end }}
 </details>
 
 <details>
   <!-- prettier-ignore -->
   <summary><code>$ cat <a href='{{ $ghrepo }}/blob/{{ $git_hash }}/package.json'>package.json</a></code></summary>
-  {{ with os.ReadFile "package.json" }}
-    {{ highlight (trim . "\n\r") "json" }}
+  {{ with os.ReadFile "package.json" }} {{ highlight (trim . "\n\r") "json" }}
   {{ end }}
 </details>

--- a/layouts/debug.html
+++ b/layouts/debug.html
@@ -63,16 +63,18 @@
 
 <h2>Dependencies</h2>
 
+<!-- prettier-ignore -->
 <details>
-  <!-- prettier-ignore -->
   <summary><code>$ cat <a href='{{ $ghrepo }}/blob/{{ $git_hash }}/flake.lock'>flake.lock</a></code></summary>
-  {{ with os.ReadFile "flake.lock" }} {{ highlight (trim . "\n\r") "json" }} {{
-  end }}
+  {{ with os.ReadFile "flake.lock" }}
+    {{ highlight (trim . "\n\r") "json" }}
+  {{ end }}
 </details>
 
+<!-- prettier-ignore -->
 <details>
-  <!-- prettier-ignore -->
   <summary><code>$ cat <a href='{{ $ghrepo }}/blob/{{ $git_hash }}/package.json'>package.json</a></code></summary>
-  {{ with os.ReadFile "package.json" }} {{ highlight (trim . "\n\r") "json" }}
+  {{ with os.ReadFile "package.json" }}
+    {{ highlight (trim . "\n\r") "json" }}
   {{ end }}
 </details>

--- a/layouts/debug.html
+++ b/layouts/debug.html
@@ -67,9 +67,7 @@
   <!-- prettier-ignore -->
   <summary><code>$ cat <a href='{{ $ghrepo }}/blob/{{ $git_hash }}/flake.lock'>flake.lock</a></code></summary>
   {{ with os.ReadFile "flake.lock" }}
-  <pre>
     {{ highlight (trim . "\n\r") "json" }}
-  </pre>
   {{ end }}
 </details>
 
@@ -77,8 +75,6 @@
   <!-- prettier-ignore -->
   <summary><code>$ cat <a href='{{ $ghrepo }}/blob/{{ $git_hash }}/package.json'>package.json</a></code></summary>
   {{ with os.ReadFile "package.json" }}
-  <pre>
     {{ highlight (trim . "\n\r") "json" }}
-  </pre>
   {{ end }}
 </details>


### PR DESCRIPTION
removes a ton of margin between the dropdown and actual codeblock

<img width="3384" height="2186" alt="image" src="https://github.com/user-attachments/assets/446eed5e-5b87-4b4f-98d7-623ff8bab6d0" />

<img width="3384" height="2186" alt="image" src="https://github.com/user-attachments/assets/2b245f7b-449d-4273-95de-89f4152b0311" />
