### PR TITLE
Revert "feat(debug): track the number of git commits different"

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,8 +1,6 @@
 use flake
 
 HUGO_DART_SASS_VERSION=$(dart-sass --version)
-HUGO_GIT_DIFF_STAT=$(git diff --stat origin/main origin/staging)
-HUGO_GIT_DIFF_COUNT=$(git log --pretty=oneline origin/main..origin/staging | wc -l)
 HUGO_GO_VERSION=$(go version)
 HUGO_HUGO_VERSION=$(hugo version)
 HUGO_LATEST_GIT_DATE=$(git log -1 --date=iso-strict --pretty=format:"%cd" origin/main)
@@ -14,8 +12,6 @@ HUGO_NPM_VERSION=$(npm --version)
 HUGO_UNAME=$(uname --kernel-name --nodename --kernel-release --machine --processor --hardware-platform --operating-system)
 
 export HUGO_DART_SASS_VERSION
-export HUGO_GIT_DIFF_STAT
-export HUGO_GIT_DIFF_COUNT
 export HUGO_GO_VERSION
 export HUGO_HUGO_VERSION
 export HUGO_LATEST_GIT_DATE

--- a/layouts/debug.html
+++ b/layouts/debug.html
@@ -20,30 +20,15 @@
         <a href="{{ $ghrepo }}commits/{{ $git_hash }}"
           >{{ $git_subject }} ({{ $git_hash }})</a
         >
-        on {{ $git_date }}.
+        on {{ $git_date }}
       </p>
 
       <p>
         See
         <a href="{{ $ghrepo }}compare/{{ $git_hash }}...staging">differences</a>
         between <a href="{{ $ghrepo }}/tree/main ">production</a> and
-        <a href="{{ $ghrepo }}/tree/staging ">staging</a> branches.
+        <a href="{{ $ghrepo }}/tree/staging ">staging</a> branches
       </p>
-
-      <blockquote cite="">
-        <p>
-          The production branch is {{ os.Getenv "HUGO_GIT_DIFF_COUNT" }} commits
-          behind the staging branch.
-        </p>
-      </blockquote>
-
-      <details>
-        <!-- prettier-ignore -->
-        <summary><code>$ git diff --stat origin/main origin/staging</code></summary>
-        <pre>
-          {{ os.Getenv "HUGO_GIT_DIFF_STAT" }}
-        </pre>
-      </details>
 
       <h2>Hardware</h2>
 

--- a/layouts/debug.html
+++ b/layouts/debug.html
@@ -20,14 +20,14 @@
         <a href="{{ $ghrepo }}commits/{{ $git_hash }}"
           >{{ $git_subject }} ({{ $git_hash }})</a
         >
-        on {{ $git_date }}
+        on {{ $git_date }}.
       </p>
 
       <p>
         See
         <a href="{{ $ghrepo }}compare/{{ $git_hash }}...staging">differences</a>
         between <a href="{{ $ghrepo }}/tree/main ">production</a> and
-        <a href="{{ $ghrepo }}/tree/staging ">staging</a> branches
+        <a href="{{ $ghrepo }}/tree/staging ">staging</a> branches.
       </p>
 
       <h2>Hardware</h2>


### PR DESCRIPTION
Redundant information with the GitHub differences webui. Plus, it is not static information that is run _one time_. If I wanted to have something like this, I would need to rebuild/redeploy the website everyday or so

Reverts suasuasuasuasua/personal-website#88